### PR TITLE
Adicionando suporte para Cartão de Débito e Campos de Boleto

### DIFF
--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/DebitCard.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/DebitCard.java
@@ -1,0 +1,71 @@
+package cieloecommerce.sdk.ecommerce;
+
+import com.google.gson.annotations.SerializedName;
+
+public class DebitCard {
+	
+	@SerializedName("CardNumber")
+	private String cardNumber;
+
+	@SerializedName("Holder")
+	private String holder;
+
+	@SerializedName("ExpirationDate")
+	private String expirationDate;
+
+	@SerializedName("SecurityCode")
+	private String securityCode;
+	
+	@SerializedName("Brand")
+	private String brand;
+
+	public DebitCard(String securityCode, String brand) {
+		setSecurityCode(securityCode);
+		setBrand(brand);
+	}
+
+	public String getBrand() {
+		return brand;
+	}
+
+	public DebitCard setBrand(String brand) {
+		this.brand = brand;
+		return this;
+	}
+
+	public String getCardNumber() {
+		return cardNumber;
+	}
+
+	public DebitCard setCardNumber(String cardNumber) {
+		this.cardNumber = cardNumber;
+		return this;
+	}
+
+	public String getExpirationDate() {
+		return expirationDate;
+	}
+
+	public DebitCard setExpirationDate(String expirationDate) {
+		this.expirationDate = expirationDate;
+		return this;
+	}
+
+	public String getHolder() {
+		return holder;
+	}
+
+	public DebitCard setHolder(String holder) {
+		this.holder = holder;
+		return this;
+	}
+
+	public String getSecurityCode() {
+		return securityCode;
+	}
+
+	public DebitCard setSecurityCode(String securityCode) {
+		this.securityCode = securityCode;
+		return this;
+	}
+}

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/Payment.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/Payment.java
@@ -81,6 +81,8 @@ public class Payment {
 	private String identification;
 	@SerializedName("Instructions")
 	private String instructions;
+	@SerializedName("AuthenticationUrl")
+	private String authenticationUrl;
 	
 
 	public Payment(Integer amount, Integer installments) {
@@ -128,6 +130,10 @@ public class Payment {
 
 	public String getAuthorizationCode() {
 		return authorizationCode;
+	}
+
+	public String getAuthenticationUrl() {
+		return authenticationUrl;
 	}
 
 	public Payment setAuthorizationCode(String authorizationCode) {

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/Payment.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/Payment.java
@@ -19,6 +19,8 @@ public class Payment {
 	private RecurrentPayment recurrentPayment;
 	@SerializedName("CreditCard")
 	private CreditCard creditCard;
+	@SerializedName("DebitCard")
+	private DebitCard debitCard;
 	@SerializedName("Tid")
 	private String tid;
 	@SerializedName("ProofOfSale")
@@ -96,6 +98,14 @@ public class Payment {
 
 		return getCreditCard();
 	}
+	
+	public DebitCard debitCard(String securityCode, String brand) {
+		setType(Type.DebitCard);
+		setDebitCard(new DebitCard(securityCode, brand));
+
+		return getDebitCard();
+	}
+	
 
 	public RecurrentPayment recurrentPayment(boolean authorizeNow) {
 		setRecurrentPayment(new RecurrentPayment(authorizeNow));
@@ -165,6 +175,15 @@ public class Payment {
 		return this;
 	}
 
+	public Payment setDebitCard(DebitCard debitCard) {
+		this.debitCard = debitCard;
+		return this;
+	}
+	
+	public DebitCard getDebitCard() {
+		return debitCard;
+	}
+	
 	public Currency getCurrency() {
 		return currency;
 	}

--- a/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/Payment.java
+++ b/api30.sdk/src/main/java/cieloecommerce/sdk/ecommerce/Payment.java
@@ -69,6 +69,17 @@ public class Payment {
 	private String digitableLine;
 	@SerializedName("Address")
 	private String address;
+	@SerializedName("BoletoNumber")
+	private String boletoNumber;
+	@SerializedName("Assignor")
+	private String assignor;
+	@SerializedName("Demonstrative")
+	private String demonstrative;
+	@SerializedName("Identification")
+	private String identification;
+	@SerializedName("Instructions")
+	private String instructions;
+	
 
 	public Payment(Integer amount, Integer installments) {
 		setAmount(amount);
@@ -330,6 +341,42 @@ public class Payment {
 
 	public Payment setCapture(boolean capture) {
 		this.capture = capture;
+		return this;
+	}
+
+	public String getBoletoNumber() {
+		return boletoNumber;
+	}
+
+	public Payment setBoletoNumber(String boletoNumber) {
+		this.boletoNumber = boletoNumber;
+		return this;
+	}
+
+	public String getDemonstrative() {
+		return demonstrative;
+	}
+
+	public Payment setDemonstrative(String demonstrative) {
+		this.demonstrative = demonstrative;
+		return this;
+	}
+
+	public String getIdentification() {
+		return identification;
+	}
+
+	public Payment setIdentification(String identification) {
+		this.identification = identification;
+		return this;
+	}
+
+	public String getInstructions() {
+		return instructions;
+	}
+
+	public Payment setInstructions(String instructions) {
+		this.instructions = instructions;
 		return this;
 	}
 


### PR DESCRIPTION
A API está quebrada para pagamento com Cartão de Débito.
Só permite setar CreditCard.

Criado novo VO de DebitCard e métodos para estar o DebitCard, estando a transação de acordo seguindo modelo do cartão de Crédito. 

Incluido alguns campos de BOLETO que estão descritos na documentação mas não estavam contemplados na API.
